### PR TITLE
Infinite Loop in BandsHysteresis::contiguous_resolution_region

### DIFF
--- a/C++/include/BandsHysteresis.h
+++ b/C++/include/BandsHysteresis.h
@@ -131,6 +131,12 @@ private:
       BandsRegion::Region corrective_region,
       bool dir, int idx_from, int idx_to) const;
 
+  //Utility for contiguous_resolution_region
+  // Returns size - 1 if idx < 0
+  // Returns 0 if idx >= size
+  // Returns 1 if size == 1
+  int wrap_around(int idx, int size) const;
+
   // check if region is above corrective region (corrective or above)
   static bool is_up_from_corrective_region(BandsRegion::Region corrective_region, BandsRegion::Region region);
 

--- a/C++/src/BandsHysteresis.cpp
+++ b/C++/src/BandsHysteresis.cpp
@@ -246,20 +246,20 @@ bool BandsHysteresis::contiguous_resolution_region(const std::vector<BandsRange>
   int idx=idx_from;
   while (idx != idx_to && 0 <= idx && idx < static_cast<int>(ranges.size()) &&
       is_below_corrective_region(corrective_region,ranges[idx].region)) {
-    if (dir) {
-      ++idx;
-      if (mod_ > 0 &&  idx == static_cast<int>(ranges.size())) {
-        idx=0;
-      }
-    } else {
-      if (mod_ > 0 && idx == 0) {
-        idx = ranges.size()-1;
-      }
-      --idx;
+    idx += dir? 1 : -1;
+    if (mod_ > 0) {
+      wrap_around(idx, ranges.size());
     }
   }
   return 0 <= idx && idx < static_cast<int>(ranges.size()) &&
       is_below_corrective_region(corrective_region,ranges[idx].region);
+}
+
+int BandsHysteresis::wrap_around(int idx, int size) const {
+  if (size == 1) return 1;
+  if (idx < 0) return size - 1;
+  if (idx >= size) return 0;
+  return idx;
 }
 
 // Returns true if a is to the left of b (modulo mod). If mod is 0, this is the same a < b


### PR DESCRIPTION
An infinite loop is started when BandsHysteresis::contigous_resolution_region is called while the provided vector `ranges` has a size of 2, `dir` is false, and `mod_` is nonzero.  

Another loop is started when it is called with `dir` == true, `mod_` > 0, and `ranges.size()` == 1.